### PR TITLE
fix: 支付宝小程序请求header设置与读取headers

### DIFF
--- a/src/adapter/ap.js
+++ b/src/adapter/ap.js
@@ -11,21 +11,21 @@ module.exports = function (request, responseCallback) {
         method: request.method,
         url: request.url,
         dataType: 'text',
-        header: request.headers,
+        headers: request.headers,
         data: request.body || {},
         timeout: request.timeout || 20000,
         success(res) {
             responseCallback({
                 statusCode: res.status,
                 responseText: res.data,
-                statusHeaders: res.headers
+                headers: res.headers
             })
         },
         fail(res) {
             responseCallback({
                 statusCode: res.status || 0,
                 responseText: res.data,
-                statusHeaders: res.headers,
+                headers: res.headers,
                 errMsg: statusList[res.status] || ""
             })
         }


### PR DESCRIPTION
支付宝小程序adapter设置request header无效，response headers调用callback的key值传错，导致底层内部无法正常获取response header，致使parseJSON无效，无法自动将response body转为JSON对象