### PR TITLE
feat: 拓展ts类型提示

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,8 @@ export interface FlyResponse<T = any> {
     request: FlyRequestConfig;
     engine: XMLHttpRequest;
     headers: Object;
+    status:number;
+    statusText:string
 }
 
 export interface FlyErrResponse {
@@ -34,6 +36,8 @@ export interface FlyErrResponse {
 
 export interface FlyPromise<T = any> extends Promise<FlyResponse<T>> {
 }
+
+export type UntieResponse<T = any, O = any> = O extends keyof FlyResponse ? Promise<FlyResponse<T>[O]> : Promise<FlyResponse<T>>  
 
 export interface FlyRequestInterceptor<V> {
     use(onSend?: (request: V) => any): void;
@@ -57,11 +61,11 @@ export interface Fly {
         response:FlyResponseInterceptor<FlyResponse>;
     };
     engine:any;
-    request<T = any>(url: string, data?: any, config?: FlyRequestConfig): FlyPromise<T>;
-    get<T = any>(url: string, data?:any, config?: FlyRequestConfig): FlyPromise<T>;
+    request<D = any, T = any,O extends string = ''>(url: string, data?: D, config?: FlyRequestConfig): UntieResponse<T,O>;
+    get<D = any,T = any, O extends string = ''>(url: string, data?:D, config?: FlyRequestConfig): UntieResponse<T,O>;
     delete(url: string, data?:any, config?: FlyRequestConfig): FlyPromise;
     head(url: string,data?:any, config?: FlyRequestConfig): FlyPromise;
-    post<T = any>(url: string, data?: any, config?: FlyRequestConfig): FlyPromise<T>;
+    post<D = any,T = any, O extends string = ''>(url: string, data?: D, config?: FlyRequestConfig): UntieResponse<T,O>;
     put<T = any>(url: string, data?: any, config?: FlyRequestConfig): FlyPromise<T>;
     patch<T = any>(url: string, data?: any, config?: FlyRequestConfig): FlyPromise<T>;
     all<T>(values: (T | Promise<T>)[]): Promise<T[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ export interface FlyRequestInterceptor<V> {
 
     clear(): void;
 }
-export interface FlyResponseInterceptor<V> {
+export interface FlyResponseInterceptor<V = FlyResponse> {
     use(onSucceed?: (response: V) => any, onError?: (err: Error) => any): void;
     lock(): void;
     unlock(): void;


### PR DESCRIPTION
把`request`,`get`,`post`的单一`any`泛型去掉，拓展了更友好的`ts`提示，可以定义请求`data`的类型和返回类型
```ts
type wxLoginRes = 'code' | 'encryptedData' | 'iv' | 'rawData' | 'signature'
type loginToken = Record<'encryptedData' | 'expirationTimeSeconds' | 'signature', string>
interface loginRes {
  loginToken: loginToken
}

fly.post<Record<wxLoginRes, string>, loginRes>('xxx', {
  code,
  encryptedData,
  iv,
  signature,
  rawData
}).then(res=>{
  res.data.loginToken
})
```
还可以解构`response`,只需加上你想要解构的字段就可以,主要用到了`UntieResponse`类型
```ts
fly.post<Record<wxLoginRes, string>, loginRes>('xxx', {
  code,
  encryptedData,
  iv,
  signature,
  rawData
},'data').then(res=>{
  res.loginToken
})
```
我觉得这样会更好